### PR TITLE
Update docker files with dependency tags / git SHAs

### DIFF
--- a/docker/aurora-deps-fedora/Dockerfile
+++ b/docker/aurora-deps-fedora/Dockerfile
@@ -2,7 +2,7 @@
 # docker build -t aurora-deps-ubuntu --build-arg compile_cores=8 .
 
 # Get MOOSE image
-FROM helenbrooks/moose-fedora
+FROM helenbrooks/moose-fedora:2021-04
 
 # By default one core is used to compile
 ARG compile_cores=1
@@ -44,12 +44,13 @@ RUN cd /home/dagmc-bld && \
     -DCMAKE_C_COMPILER=$CC \
     -DEMBREE_ISPC_SUPPORT=0 && \
     make -j"$compile_cores" && \
-    make install 
+    make install
 
 # Build DoubleDown
 RUN cd /home/dagmc-bld && \
     git clone https://github.com/pshriwise/double-down && \
     cd double-down && \
+    git checkout v1.0.0 && \
     mkdir build && \
     cd build && \
     cmake ../ \
@@ -58,14 +59,14 @@ RUN cd /home/dagmc-bld && \
     -DCMAKE_INSTALL_PREFIX=/home/double-down && \
     make -j"$compile_cores" && \
     make install
-    
+
 # Build DagMC
 RUN cd /home/dagmc-bld && \
     mkdir dagmc && \
     cd dagmc && \
     git clone https://github.com/svalinn/DAGMC && \
     cd DAGMC && \
-    git checkout develop && \
+    git checkout 0d07a744178af6275959c745fa4362d8b4d13559 && \
     cd ../ && \
     mkdir build && \
     cd build && \
@@ -94,7 +95,7 @@ RUN mkdir /home/openmc-bld && \
     cd /home/openmc-bld && \
     git clone https://github.com/openmc-dev/openmc.git && \
     cd openmc && \
-    git checkout develop && \
+    git checkout b62708f911d05e269e5c3083287e70d050ed35f9 && \
     cd ../ && \
     mkdir build && \
     cd build && \
@@ -108,5 +109,3 @@ RUN mkdir /home/openmc-bld && \
 
 ENV PATH=$PATH:/home/moab/bin:/home/openmc/bin:/home/dagmc/bin
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/moab/lib:/home/dagmc/lib
-
-

--- a/docker/aurora-deps-ubuntu/Dockerfile
+++ b/docker/aurora-deps-ubuntu/Dockerfile
@@ -5,7 +5,7 @@
 ARG compile_cores=1
 
 # Get MOOSE image
-FROM helenbrooks/moose-ubuntu
+FROM helenbrooks/moose-ubuntu:2021-04
 
 # Get MOAB / Embree / DagMC dependencies
 RUN apt-get update && apt-get -y install \
@@ -45,12 +45,13 @@ RUN cd /home/dagmc-bld && \
     -DCMAKE_C_COMPILER=$CC \
     -DEMBREE_ISPC_SUPPORT=0 && \
     make -j"$compile_cores" && \
-    make install 
+    make install
 
 # Build DoubleDown
 RUN cd /home/dagmc-bld && \
     git clone https://github.com/pshriwise/double-down && \
     cd double-down && \
+    git checkout v1.0.0 && \
     mkdir build && \
     cd build && \
     cmake ../ \
@@ -59,14 +60,14 @@ RUN cd /home/dagmc-bld && \
     -DCMAKE_INSTALL_PREFIX=/home/double-down && \
     make -j"$compile_cores" && \
     make install
-    
+
 # Build DagMC
 RUN cd /home/dagmc-bld && \
     mkdir dagmc && \
     cd dagmc && \
     git clone https://github.com/svalinn/DAGMC && \
     cd DAGMC && \
-    git checkout develop && \
+    git checkout 0d07a744178af6275959c745fa4362d8b4d13559 && \
     cd ../ && \
     mkdir build && \
     cd build && \
@@ -95,7 +96,7 @@ RUN mkdir /home/openmc-bld && \
     cd /home/openmc-bld && \
     git clone https://github.com/openmc-dev/openmc.git && \
     cd openmc && \
-    git checkout develop && \
+    git checkout b62708f911d05e269e5c3083287e70d050ed35f9 && \
     cd ../ && \
     mkdir build && \
     cd build && \
@@ -109,5 +110,3 @@ RUN mkdir /home/openmc-bld && \
 
 ENV PATH=$PATH:/home/moab/bin:/home/openmc/bin:/home/dagmc/bin
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/moab/lib:/home/dagmc/lib
-
-

--- a/docker/aurora-fedora/Dockerfile
+++ b/docker/aurora-fedora/Dockerfile
@@ -5,7 +5,7 @@
 # docker build -t aurora-ubuntu --build-arg build_git_sha=${GITHUB_SHA} .
 
 # Get MOOSE image with aurora deps
-FROM helenbrooks/aurora-deps-fedora:v.0.2.0
+FROM helenbrooks/aurora-deps-fedora:v.0.2.1
 
 # By default one core is used to compile
 ARG compile_cores=1

--- a/docker/aurora-ubuntu/Dockerfile
+++ b/docker/aurora-ubuntu/Dockerfile
@@ -8,7 +8,7 @@
 # docker build -t aurora-ubuntu --build-arg test_coverage=true .
 
 # Get MOOSE image with aurora deps
-FROM helenbrooks/aurora-deps-ubuntu:v.0.2.0
+FROM helenbrooks/aurora-deps-ubuntu:v.0.2.1
 
 # By default one core is used to compile
 ARG compile_cores=1


### PR DESCRIPTION
To protect from breaking changes in dependencies, update Docker files with dependency tags or git SHAs (for where no tag exists).