### PR TITLE
Update input params

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: BuildTest
 on:
+  workflow_dispatch:
+
   push:
     branches:
        - main

--- a/include/functions/VariableFunction.h
+++ b/include/functions/VariableFunction.h
@@ -6,9 +6,6 @@
 
 class VariableFunction;
 
-template <>
-InputParameters validParams<VariableFunction>();
-
 /**
    \brief Function object which returns the value of a variable at a point.
 

--- a/include/transfers/MoabMeshTransfer.h
+++ b/include/transfers/MoabMeshTransfer.h
@@ -11,9 +11,6 @@
 class MultiApp;
 class MoabMeshTransfer;
 
-template <>
-InputParameters validParams<MoabMeshTransfer>();
-
 /**
    \brief Transfer a pointer to the FEProblem from the parent to child app in a MultiApp.
 
@@ -31,6 +28,8 @@ class MoabMeshTransfer : public MultiAppTransfer
   virtual void execute();
 
   virtual void initialSetup();
+
+  static InputParameters validParams();
 
  private:
 

--- a/include/userobject/FunctionUserObject.h
+++ b/include/userobject/FunctionUserObject.h
@@ -11,9 +11,6 @@
 // Forward declaration
 class FunctionUserObject;
 
-template <>
-InputParameters validParams<FunctionUserObject>();
-
 /** \brief This UserObject class creates a function from a variable in memory given
  *  a string containing the variable name.
  */
@@ -22,6 +19,8 @@ class FunctionUserObject : public GeneralUserObject
  public:
 
   FunctionUserObject(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
   /// Sets the mesh function from a variable in memory
   virtual void execute() override;

--- a/openmc/include/executioners/OpenMCExecutioner.h
+++ b/openmc/include/executioners/OpenMCExecutioner.h
@@ -43,9 +43,6 @@
 
 class OpenMCExecutioner;
 
-template <>
-InputParameters validParams<OpenMCExecutioner>();
-
 /// \brief Our bespoke Executioner class to perform OpenMC runs
 class OpenMCExecutioner : public Transient
 {
@@ -53,6 +50,8 @@ public:
   OpenMCExecutioner(const InputParameters & parameters);
 
   ~OpenMCExecutioner();
+
+  static InputParameters validParams();
 
   /** \brief Perform a full OpenMC run
 

--- a/openmc/include/problem/OpenMCProblem.h
+++ b/openmc/include/problem/OpenMCProblem.h
@@ -4,9 +4,6 @@
 
 class OpenMCProblem;
 
-template <>
-InputParameters validParams<OpenMCProblem>();
-
 /** \brief Minimal definition for a FE problem.
 
     Only included as it is required by Moose
@@ -20,6 +17,8 @@ class OpenMCProblem : public ExternalProblem
  public:
   OpenMCProblem (const InputParameters & parameters) :
   ExternalProblem(parameters)  {};
+
+  static InputParameters validParams();
 
   /// Does nothing
   virtual void externalSolve () override {};

--- a/openmc/include/userobject/MoabUserObject.h
+++ b/openmc/include/userobject/MoabUserObject.h
@@ -30,8 +30,6 @@ struct MOABMaterialProperties{
 // Forward Declarations
 class MoabUserObject;
 
-template <>
-InputParameters validParams<MoabUserObject>();
 
 /**
     \brief UserObject class which wraps a moab::Interface pointer.
@@ -46,6 +44,8 @@ class MoabUserObject : public UserObject
  public:
 
   MoabUserObject(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
   /// Override MOOSE virtual method to do nothing
   virtual void execute(){};

--- a/openmc/src/executioners/OpenMCExecutioner.C
+++ b/openmc/src/executioners/OpenMCExecutioner.C
@@ -3,11 +3,11 @@
 
 registerMooseObject("OpenMCApp", OpenMCExecutioner);
 
-template <>
+
 InputParameters
-validParams<OpenMCExecutioner>()
+OpenMCExecutioner::validParams()
 {
-  InputParameters params = validParams<Transient>();
+  InputParameters params = Transient::validParams();
 
   // Location for results
   params.addParam<std::vector<std::string>>("variables", std::vector<std::string>(1,"heating-local"),

--- a/openmc/src/problem/OpenMCProblem.C
+++ b/openmc/src/problem/OpenMCProblem.C
@@ -2,10 +2,9 @@
 
 registerMooseObject("OpenMCApp", OpenMCProblem);
 
-template <>
 InputParameters
-validParams<OpenMCProblem>()
+OpenMCProblem::validParams()
 {
-  InputParameters params = validParams<ExternalProblem>();
+  InputParameters params = ExternalProblem::validParams();
   return params;
 }

--- a/openmc/src/userobject/MoabUserObject.C
+++ b/openmc/src/userobject/MoabUserObject.C
@@ -6,11 +6,10 @@
 
 registerMooseObject("OpenMCApp", MoabUserObject);
 
-template <>
 InputParameters
-validParams<MoabUserObject>()
+MoabUserObject::validParams()
 {
-  InputParameters params = validParams<UserObject>();
+  InputParameters params = UserObject::validParams();
 
   // MOAB mesh params
   params.addParam<double>("length_scale", 100.,"Scale factor to convert lengths from MOOSE to MOAB. Default is from metres->centimetres.");

--- a/src/functions/VariableFunction.C
+++ b/src/functions/VariableFunction.C
@@ -3,8 +3,6 @@
 
 registerMooseObject("AuroraApp", VariableFunction);
 
-defineLegacyParams(VariableFunction);
-
 InputParameters
 VariableFunction::validParams()
 {

--- a/src/transfers/MoabMeshTransfer.C
+++ b/src/transfers/MoabMeshTransfer.C
@@ -3,11 +3,10 @@
 
 registerMooseObject("AuroraApp", MoabMeshTransfer);
 
-template <>
 InputParameters
-validParams<MoabMeshTransfer>()
+MoabMeshTransfer::validParams()
 {
-  InputParameters params = validParams<MultiAppTransfer>();
+  InputParameters params = MultiAppTransfer::validParams();
 
   params.addParam<std::string>("apptype_from", "AuroraTestApp","Type of app from which we are taking mesh and systems.");
   params.addParam<std::string>("apptype_to", "OpenMCApp","Type of app to which we are sending mesh and systems.");

--- a/src/userobject/FunctionUserObject.C
+++ b/src/userobject/FunctionUserObject.C
@@ -3,11 +3,10 @@
 
 registerMooseObject("AuroraApp", FunctionUserObject);
 
-template <>
 InputParameters
-validParams<FunctionUserObject>()
+FunctionUserObject::validParams()
 {
-  InputParameters params = validParams<GeneralUserObject>();
+  InputParameters params = GeneralUserObject::validParams();
 
   params.addRequiredParam<std::string>(
       "variable", "Variable name to evaluate the mesh function on.");


### PR DESCRIPTION
This updates the legacy `InputParameter` specification as it is now deprecated (see [here](mooseframework.org/newsletter/2021_11.html#legacy-input-parameter-deprecation))

This fixes the following build error and allows Aurora to be built with the MOOSE `master` branch.

```
/home/pshriwise/opt/aurora/src/moose/framework/build/header_symlinks/MooseTypes.h:485:17: error: static assertion failed: defineLegacyParams is no longer supported as legacy input parameter construction is no longer supported; see mooseframework.org/newsletter/2021_11.html#legacy-input-parameter-deprecation for more information
  485 |   static_assert(false,                                                                             \
      |                 ^~~~~
/home/pshriwise/opt/aurora/src/moose/framework/build/header_symlinks/MooseTypes.h:485:17: note: in definition of macro ‘defineLegacyParams’
  485 |   static_assert(false,                                                                             \
      |                 ^~~~~
```