### PR TITLE
Update to latest MOOSE in CI

### DIFF
--- a/docker/aurora-deps-fedora/Dockerfile
+++ b/docker/aurora-deps-fedora/Dockerfile
@@ -1,13 +1,11 @@
 # To make use of multiple cores during the compile stages of the docker build
-# docker build -t aurora-deps-ubuntu --build-arg compile_cores=8 .
+# docker build -t aurora-deps-fedora --build-arg compile_cores=8 .
 
 # Get MOOSE image
-FROM helenbrooks/moose-fedora:2021-04
+FROM helenbrooks/moose-fedora:2022-07-21
 
 # By default one core is used to compile
-ARG compile_cores=1
-
-RUN echo Builing with "$compile_cores" cores.
+ARG compile_cores=4
 
 # Build MOAB
 RUN mkdir /home/dagmc-bld

--- a/docker/aurora-deps-ubuntu/Dockerfile
+++ b/docker/aurora-deps-ubuntu/Dockerfile
@@ -14,8 +14,8 @@ RUN apt-get update && apt-get -y install \
     pkg-config
 
 # Build MOAB
-RUN mkdir /home/dagmc-bld
-RUN cd /home/dagmc-bld && \
+RUN mkdir /home/dagmc-bld && \
+    cd /home/dagmc-bld && \
     git clone https://bitbucket.org/fathomteam/moab && \
     cd moab && \
     git checkout Version5.2.0 && \

--- a/docker/aurora-deps-ubuntu/Dockerfile
+++ b/docker/aurora-deps-ubuntu/Dockerfile
@@ -1,18 +1,16 @@
 # To make use of multiple cores during the compile stages of the docker build
 # docker build -t aurora-deps-ubuntu --build-arg compile_cores=8 .
-
-# By default one core is used to compile
-ARG compile_cores=1
-
 # Get MOOSE image
-FROM helenbrooks/moose-ubuntu:2021-04
+FROM helenbrooks/moose-ubuntu:2022-07-21
+
+# By default 4 cores are used to compile
+ARG compile_cores=4
 
 # Get MOAB / Embree / DagMC dependencies
 RUN apt-get update && apt-get -y install \
     libeigen3-dev \
-    libhdf5-dev \
-    libglfw3-dev \
-    libtbb-dev \
+    libglfw3-dev  \
+    libtbb-dev  \
     pkg-config
 
 # Build MOAB

--- a/docker/aurora-fedora/Dockerfile
+++ b/docker/aurora-fedora/Dockerfile
@@ -6,10 +6,10 @@
 #              -f docker/aurora-fedora/Dockerfile .
 
 # Get MOOSE image with aurora deps
-FROM helenbrooks/aurora-deps-fedora:v.0.3.0
+FROM helenbrooks/aurora-deps-fedora:v.0.3.1
 
-# By default one core is used to compile
-ARG compile_cores=1
+# By default four cores are used to compile
+ARG compile_cores=4
 
 # Copy entire repository into image
 COPY ./ /home/aurora/

--- a/docker/aurora-ubuntu/Dockerfile
+++ b/docker/aurora-ubuntu/Dockerfile
@@ -11,10 +11,10 @@
 #              -f docker/aurora-ubuntu/Dockerfile .
 
 # Get MOOSE image with aurora deps
-FROM helenbrooks/aurora-deps-ubuntu:v.0.3.0
+FROM helenbrooks/aurora-deps-ubuntu:v.0.3.1
 
-# By default one core is used to compile
-ARG compile_cores=1
+# By default 4 cores are used to compile
+ARG compile_cores=4
 
 # Should we generate a coverage report
 ARG test_coverage=false

--- a/docker/aurora-ubuntu/Dockerfile
+++ b/docker/aurora-ubuntu/Dockerfile
@@ -53,7 +53,7 @@ RUN if "$test_coverage" ; then \
     ./run_tests
 
 # Generate test coverage report using coveralls and upload
-RUN if "$test_coverage" && "$coveralls_token" != "" ; then \
+RUN if "$test_coverage" && ! [ "$coveralls_token" = "" ] ; then \
        echo "Uploading test coverage to coveralls"; \
        export COVERALLS_REPO_TOKEN="$coveralls_token" && \
        export CI_BRANCH="$coveralls_branch" && \

--- a/docker/moose-fedora/Dockerfile
+++ b/docker/moose-fedora/Dockerfile
@@ -5,7 +5,7 @@
 FROM fedora:33
 
 # By default one core is used to compile
-ARG compile_cores=1
+ARG compile_cores=4
 
 RUN echo "Building with $compile_cores cores"
 
@@ -41,34 +41,95 @@ ENV CXX=mpicxx
 ENV F90=mpif90
 ENV F77=mpif77
 ENV FC=mpif90
-ENV MOOSE_JOBS="$compile_cores"
 
-# Get MOOSE source
+# Optional build-arg to specify moose version
+ARG moose_tag=
+ARG moose_git_sha=
+
+# Get MOOSE source code and checkout the desired version
 RUN cd /home/ && \
     git clone https://github.com/idaholab/moose.git && \
     cd moose && \
-    git checkout master
+    if ! [ "$moose_tag" = "" ] ; then \
+       git fetch --tags && \
+       git checkout tags/"$moose_tag" -b master; \
+    elif ! [ "$moose_git_sha" = "" ] ; then \
+       git checkout "$moose_git_sha"; \
+    else \
+       git checkout master; \
+    fi && \
+    git log -1
 
-# Make PETSC
-RUN cd /home/moose &&  \
-    ./scripts/update_and_rebuild_petsc.sh --prefix=/home/petsc
+# Specify number of cores for compilation
+ARG compile_cores=4
+ENV MOOSE_JOBS=$compile_cores
+
+RUN cd /home/moose && \
+    git submodule update --init --recursive petsc
+
+ENV PETSC_ARCH=arch-moose
+ENV PETSC_DIR=/home/moose/petsc
+
+# Configure PETSC ourselves because MOOSE script can't find HDF5 on Fedora
+RUN cd /home/moose/petsc && \
+    ./configure --download-hypre=1 \
+                --prefix=/home/petsc \
+                --CC=$CC \
+                --CXX=$CXX \
+                --FC=$FC \
+                --with-shared-libraries=1 \
+                --with-hdf5=1 \
+                --with-make-np="$MOOSE_JOBS" \
+                --with-debugging=no \
+                --download-fblaslapack=1 \
+                --download-metis=1 \
+                --download-ptscotch=1 \
+                --download-parmetis=1 \
+                --download-superlu_dist=1 \
+                --download-mumps=1 \
+                --download-strumpack=1 \
+                --download-scalapack=1 \
+                --download-slepc=1 \
+                --with-mpi=1 \
+                --with-openmp=1 \
+                --with-cxx-dialect=C++11 \
+                --with-fortran-bindings=0 \
+                --with-sowing=0 \
+                --with-64-bit-indices
+
+RUN cd /home/moose/petsc && \
+    make all && \
+    make install
+
 ENV PETSC_DIR=/home/petsc
 
 # Make libMesh
 RUN cd /home/moose && \
-    ./scripts/update_and_rebuild_libmesh.sh --with-mpi
+    METHODS="opt" ./scripts/update_and_rebuild_libmesh.sh --with-mpi
+
+# Allow specification of MOOSE configuration flags
+ARG moose_configure_flags=""
 
 # Make MOOSE framework
 RUN cd /home/moose/ && \
-    ./configure --with-derivative-size=200 --with-ad-indexing-type=global && \
+    ./configure "$moose_configure_flags"  && \
     cd test && \
-    make -j"$compile_cores" && \
-     ./run_tests -j"$compile_cores"
-ENV MOOSE_DIR=/home/moose
+    METHOD="opt" make -j"$compile_cores"
 
 # Make MOOSE modules
 RUN cd /home/moose/modules && \
-    make -j"$compile_cores"  && \
-    ./run_tests -j"$compile_cores"
+    make -j"$compile_cores"
+
+ENV MOOSE_DIR=/home/moose
+
+# We need rsync for the tests
+RUN dnf -y install rsync
+
+# Run tests
+RUN cd /home/moose/test && \
+    ./run_tests -j "$compile_cores"
+
+RUN cd /home/moose/modules && \
+    ./run_tests -j "$compile_cores"
 
     

--- a/docker/moose-ubuntu/Dockerfile
+++ b/docker/moose-ubuntu/Dockerfile
@@ -4,6 +4,8 @@
 # docker build -t moose-ubuntu:tagname --build-arg moose_tag=tag .
 # Build with git sha
 # docker build -t moose-ubuntu:tagname --build-arg moose_git_sha=gitsha .
+# Build with particular configuration arguments
+# docker build -t moose-ubuntu:tagname --build-arg moose_configure_flags=config .
 
 # Basic environment
 FROM ubuntu:20.04
@@ -87,9 +89,14 @@ ENV PETSC_DIR=/home/petsc
 RUN cd /home/moose && \
     METHODS="opt" ./scripts/update_and_rebuild_libmesh.sh --with-mpi
 
+# Allow specification of MOOSE configuration flags
+ARG moose_configure_flags=""
+
+RUN echo "$moose_configure_flags"
+
 # Make MOOSE framework
 RUN cd /home/moose/ && \
-    ./configure --with-derivative-size=200 --with-ad-indexing-type=global && \
+    ./configure "$moose_configure_flags"  && \
     cd test && \
     METHOD="opt" make -j"$compile_cores"
 

--- a/docker/moose-ubuntu/Dockerfile
+++ b/docker/moose-ubuntu/Dockerfile
@@ -92,8 +92,6 @@ RUN cd /home/moose && \
 # Allow specification of MOOSE configuration flags
 ARG moose_configure_flags=""
 
-RUN echo "$moose_configure_flags"
-
 # Make MOOSE framework
 RUN cd /home/moose/ && \
     ./configure "$moose_configure_flags"  && \
@@ -111,12 +109,12 @@ ENV MOOSE_DIR=/home/moose
 ENV OMPI_ALLOW_RUN_AS_ROOT=1
 ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
-# RUN tests
+# Run tests
 RUN cd /home/moose/test && \
     ./run_tests -j "$compile_cores"
 
-#RUN cd /home/moose/modules && \
-#    ./run_tests -j "$compile_cores"
+RUN cd /home/moose/modules && \
+    ./run_tests -j "$compile_cores"
 
 # Unset these variables we set before
 ENV OMPI_ALLOW_RUN_AS_ROOT=

--- a/docker/moose-ubuntu/Dockerfile
+++ b/docker/moose-ubuntu/Dockerfile
@@ -1,60 +1,116 @@
-FROM ubuntu:20.04
+# Basic usage:
+# docker build -t moose-ubuntu .
+# Build with tag
+# docker build -t moose-ubuntu:tagname --build-arg moose_tag=tag .
+# Build with git sha
+# docker build -t moose-ubuntu:tagname --build-arg moose_git_sha=gitsha .
+
 # Basic environment
+FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/London
-RUN apt-get update && apt-get -y install \
-    cmake \
-    gcc \
-    g++ \
-    gfortran \
-    git \
-    libopenmpi3 \
-    python3 \
-    python3-dev \
-    python3-distutils \
-    python-is-python3 \
-    wget
+
+# We need to update package lists to get latest cmake
+RUN apt-get update && \
+    apt-get -y install \
+        software-properties-common \
+        lsb-release && \
+    apt-get clean all && \
+    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6AF7F09730B3F0A4 && \
+    apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" && \
+    apt-get update && \
+    apt-get install -y kitware-archive-keyring && \
+    rm /etc/apt/trusted.gpg.d/kitware.gpg && \
+    apt-get install -y cmake \
+            gcc \
+            g++ \
+            gfortran \
+            git \
+            libopenmpi3 \
+            python3 \
+            python3-dev \
+            python3-distutils \
+            python-is-python3 \
+            rsync
+
 # PETSC dependencies
 RUN apt-get -y install \
     bison \
     flex \
     libblas-dev \
-    liblapack-dev
+    liblapack-dev \
+    libhdf5-dev
+
 # MPI environment variables
 ENV CC=mpicc
 ENV CXX=mpicxx
 ENV F90=mpif90
 ENV F77=mpif77
 ENV FC=mpif90
-# Get MOOSE source code
+
+# Optional build-arg to specify moose version
+ARG moose_tag=
+ARG moose_git_sha=
+
+# Get MOOSE source code and checkout the desired version
 RUN cd /home/ && \
     git clone https://github.com/idaholab/moose.git && \
     cd moose && \
-    git checkout master
-ENV MOOSE_JOBS=4
+    if ! [ "$moose_tag" = "" ] ; then \
+       git fetch --tags && \
+       git checkout tags/"$moose_tag" -b master; \
+    elif ! [ "$moose_git_sha" = "" ] ; then \
+       git checkout "$moose_git_sha"; \
+    else \
+       git checkout master; \
+    fi && \
+    git log -1
+
+# Specify number of cores for compilation
+ARG compile_cores=4
+ENV MOOSE_JOBS=$compile_cores
+
+# Tell PETSC where to find HDF5
+ENV HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/serial/
+
 # Make PETSC
 RUN cd /home/moose && \
-    ./scripts/update_and_rebuild_petsc.sh --prefix=/home/petsc
+    ./scripts/update_and_rebuild_petsc.sh --prefix=/home/petsc \
+                                          --CC=$CC \
+                                          --CXX=$CXX \
+                                          --FC=$FC
+
 ENV PETSC_DIR=/home/petsc
+
 # Make libMesh
 RUN cd /home/moose && \
-    ./scripts/update_and_rebuild_libmesh.sh --with-mpi
+    METHODS="opt" ./scripts/update_and_rebuild_libmesh.sh --with-mpi
+
 # Make MOOSE framework
 RUN cd /home/moose/ && \
     ./configure --with-derivative-size=200 --with-ad-indexing-type=global && \
     cd test && \
-    make -j4
+    METHOD="opt" make -j"$compile_cores"
+
+# Make MOOSE modules
+RUN cd /home/moose/modules && \
+    make -j"$compile_cores"
+
+ENV MOOSE_DIR=/home/moose
+
 # This is needed or it mpiexec complains because docker runs as root
 # Discussion on this issue https://github.com/open-mpi/ompi/issues/4451
 ENV OMPI_ALLOW_RUN_AS_ROOT=1
 ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+
+# RUN tests
 RUN cd /home/moose/test && \
-    ./run_tests -j 4
-ENV MOOSE_DIR=/home/moose
-# Make MOOSE modules
-RUN cd /home/moose/modules && \
-    make -j4  && \
-    ./run_tests -j 4
+    ./run_tests -j "$compile_cores"
+
+#RUN cd /home/moose/modules && \
+#    ./run_tests -j "$compile_cores"
+
 # Unset these variables we set before
 ENV OMPI_ALLOW_RUN_AS_ROOT=
 ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=

--- a/openmc/unit/openmc_app_inputs/density.i
+++ b/openmc/unit/openmc_app_inputs/density.i
@@ -57,6 +57,7 @@
   []
   [test_density]
     type = OpenMCDensity
+    displacements = 'disp_x disp_y disp_z'
     density = 8.0
   []
   [elasticity_tensor]


### PR DESCRIPTION
Update docker files used in CI to work with the current version of MOOSE.

This  pertains to issue #19, but initially CI will fail without the additional changes added in PR #18.